### PR TITLE
更换随机算法

### DIFF
--- a/src/main_test.go
+++ b/src/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func init() {
+	laohuangliList.init()
+}
+func TestRandom(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		fmt.Println(laohuangliList.random())
+	}
+}
+func BenchmarkRandom(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		laohuangliList.random()
+	}
+}
+func BenchmarkRandomFromID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		laohuangliList.randomFromDateAndID(time.Now(), 12345)
+	}
+}

--- a/src/nominate.go
+++ b/src/nominate.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/adrg/strutil"
-	"github.com/adrg/strutil/metrics"
 	tele "gopkg.in/telebot.v3"
 )
 
@@ -190,10 +189,8 @@ func nominationValidCheck(content string, nominator string) (result int, respons
 			}
 		}
 	}
-	compareMethod := metrics.NewJaro()
-	compareMethod.CaseSensitive = false
 	for _, v := range laohuangliList {
-		similarity := strutil.Similarity(content, v.Content, compareMethod)
+		similarity := strutil.Similarity(content, v.Content, gStrCompareAlgo)
 		similarPush(similarContent{
 			Similarity: similarity,
 			Content:    v.Content,
@@ -201,7 +198,7 @@ func nominationValidCheck(content string, nominator string) (result int, respons
 		})
 	}
 	for _, v := range nominations {
-		similarity := strutil.Similarity(content, v.Content, compareMethod)
+		similarity := strutil.Similarity(content, v.Content, gStrCompareAlgo)
 		similarPush(similarContent{
 			Similarity: similarity,
 			Content:    v.Content,


### PR DESCRIPTION
> 人吶，就都不知道，自己就不可以預料

使用新的随机算法，使得算命结果将不再是可重现和可预测的。算命结果的当日稳定性由cache机制保证。
